### PR TITLE
csp configuration to report only

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -32,8 +32,8 @@ module.exports = {
         {
             resolve: `gatsby-plugin-csp`,
             options: {
-                disableOnDev: true,
-                reportOnly: false, // Changes header to Content-Security-Policy-Report-Only for csp testing purposes
+                disableOnDev: false,
+                reportOnly: true, // Changes header to Content-Security-Policy-Report-Only for csp testing purposes
                 mergeScriptHashes: true, // you can disable scripts sha256 hashes
                 mergeStyleHashes: true, // you can disable styles sha256 hashes
                 mergeDefaultDirectives: true,


### PR DESCRIPTION
Related to #69 and #79.
Switch to report only as a quick fix. Should be properly configured later.